### PR TITLE
base tcplb application

### DIFF
--- a/cmd/tcplb/flags.go
+++ b/cmd/tcplb/flags.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"net"
 	"strings"
 	"tcplb/lib/core"
@@ -13,8 +14,6 @@ const (
 	upstreamListSep = ","
 )
 
-var InvalidUpstreamListFlag = errors.New("invalid upstream list flag value")
-
 // UpstreamListValue is a flag.Value for lists of Upstream addresses.
 type UpstreamListValue struct {
 	Upstreams []core.Upstream
@@ -22,7 +21,7 @@ type UpstreamListValue struct {
 
 func (v *UpstreamListValue) String() string {
 	n := len(v.Upstreams)
-	tokens := make([]string, n, n)
+	tokens := make([]string, n)
 	for i, u := range v.Upstreams {
 		tokens[i] = u.Address
 	}
@@ -34,7 +33,8 @@ func (v *UpstreamListValue) Set(s string) error {
 	for _, token := range tokens {
 		host, port, err := net.SplitHostPort(token)
 		if err != nil {
-			return InvalidUpstreamListFlag
+			msg := fmt.Sprintf("expected upstream address of form host:port but got %s", token)
+			return errors.New(msg)
 		}
 		upstream := core.Upstream{
 			Network: defaultUpstreamNetwork,

--- a/cmd/tcplb/flags.go
+++ b/cmd/tcplb/flags.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"net"
+	"strings"
+	"tcplb/lib/core"
+)
+
+const (
+	commandName     = "tcplb"
+	upstreamListSep = ","
+)
+
+var InvalidUpstreamListFlag = errors.New("invalid upstream list flag value")
+
+// UpstreamListValue is a flag.Value for lists of Upstream addresses.
+type UpstreamListValue struct {
+	Upstreams []core.Upstream
+}
+
+func (v *UpstreamListValue) String() string {
+	n := len(v.Upstreams)
+	tokens := make([]string, n, n)
+	for i, u := range v.Upstreams {
+		tokens[i] = u.Address
+	}
+	return strings.Join(tokens, upstreamListSep)
+}
+
+func (v *UpstreamListValue) Set(s string) error {
+	tokens := strings.Split(s, upstreamListSep)
+	for _, token := range tokens {
+		host, port, err := net.SplitHostPort(token)
+		if err != nil {
+			return InvalidUpstreamListFlag
+		}
+		upstream := core.Upstream{
+			Network: defaultUpstreamNetwork,
+			Address: net.JoinHostPort(host, port),
+		}
+		v.Upstreams = append(v.Upstreams, upstream)
+	}
+	return nil
+}
+
+func newConfigFromFlags(argv []string) (*Config, error) {
+	flagSet := flag.NewFlagSet(commandName, flag.ExitOnError)
+
+	cfg := &Config{
+		ListenNetwork: defaultListenNetwork,
+	}
+
+	upstreamListVar := &UpstreamListValue{}
+
+	flagSet.StringVar(
+		&(cfg.ListenAddress),
+		"listen-address",
+		defaultListenAddress,
+		"listen address as host:port")
+	flagSet.Int64Var(
+		&(cfg.MaxConnectionsPerClient),
+		"max-conns-per-client",
+		defaultMaxConnectionsPerClient,
+		"connection limit per client. if not positive, no limit.")
+	flagSet.Var(
+		upstreamListVar,
+		"upstreams",
+		"comma-separated list of upstream as host:port")
+
+	err := flagSet.Parse(argv[1:])
+	cfg.Upstreams = upstreamListVar.Upstreams
+	return cfg, err
+}

--- a/cmd/tcplb/flags_test.go
+++ b/cmd/tcplb/flags_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/stretchr/testify/require"
+	"tcplb/lib/core"
+	"testing"
+)
+
+func TestUpstreamListValueErrorHelp(t *testing.T) {
+	v := &UpstreamListValue{
+		Upstreams: make([]core.Upstream, 0),
+	}
+	err := v.Set("localhost:443,127.*.*.*,127.0.0.1:9021")
+	require.Error(t, err)
+	require.Equal(t, "expected upstream address of form host:port but got 127.*.*.*", err.Error())
+}

--- a/cmd/tcplb/main.go
+++ b/cmd/tcplb/main.go
@@ -1,9 +1,32 @@
 package main
 
 import (
-	"log"
+	"os"
+	"tcplb/lib/slog"
 )
 
 func main() {
-	log.Println("tcplb server under construction") // TODO implement server
+	logger := slog.GetDefaultLogger()
+
+	cfg, err := newConfigFromFlags(os.Args)
+	if err != nil {
+		logger.Error(&slog.LogRecord{Msg: "failed to parse flags", Error: err})
+		os.Exit(2)
+	}
+
+	logger.Info(&slog.LogRecord{Msg: "loaded config", Details: cfg})
+
+	err = cfg.Validate()
+	if err != nil {
+		logger.Error(&slog.LogRecord{Msg: "configuration is invalid", Error: err})
+		os.Exit(2)
+	}
+
+	err = serve(logger, cfg)
+	if err != nil {
+		logger.Error(&slog.LogRecord{Msg: "server terminated abnormally", Error: err})
+		os.Exit(1)
+	}
+	logger.Info(&slog.LogRecord{Msg: "server terminated normally"})
+	os.Exit(0)
 }

--- a/cmd/tcplb/server.go
+++ b/cmd/tcplb/server.go
@@ -71,17 +71,17 @@ func makeAuthorizerFromConfig(cfg *Config) (forwarder.Authorizer, error) {
 	return authz.NewStaticAuthorizer(authzCfg), nil
 }
 
-// IdiotDialer attempts to dial an arbitrary candidate and gives up if that fails.
-// This is a placeholder implementation with various issues:
+// PlaceholderDialer attempts to dial an arbitrary candidate and gives up if that fails.
+// This is implementation has various issues:
 // - no timeout
 // - it doesn't attempt to balance load
 // - it doesn't try alternative upstreams if one attempt fails
 // - it doesn't learn anything
-type IdiotDialer struct {
+type PlaceholderDialer struct {
 	Logger slog.Logger
 }
 
-func (d IdiotDialer) DialBestUpstream(ctx context.Context, candidates core.UpstreamSet) (core.Upstream, forwarder.DuplexConn, error) {
+func (d PlaceholderDialer) DialBestUpstream(ctx context.Context, candidates core.UpstreamSet) (core.Upstream, forwarder.DuplexConn, error) {
 	for c := range candidates {
 		conn, err := net.Dial(c.Network, c.Address)
 		if err != nil {
@@ -96,12 +96,12 @@ func (d IdiotDialer) DialBestUpstream(ctx context.Context, candidates core.Upstr
 			break
 		}
 	}
-	return core.Upstream{}, nil, errors.New("idiot dialer failed to dial")
+	return core.Upstream{}, nil, errors.New("PlaceholderDialer failed to dial")
 }
 
 func makeDialerFromConfig(cfg *Config, logger slog.Logger) (forwarder.BestUpstreamDialer, error) {
 	// TODO FIXME replace with something better
-	return IdiotDialer{Logger: logger}, nil
+	return PlaceholderDialer{Logger: logger}, nil
 }
 
 func makeForwarderFromConfig(cfg *Config) (forwarder.Forwarder, error) {

--- a/cmd/tcplb/server.go
+++ b/cmd/tcplb/server.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"tcplb/lib/authn"
+	"tcplb/lib/authz"
+	"tcplb/lib/core"
+	"tcplb/lib/forwarder"
+	"tcplb/lib/limiter"
+	"tcplb/lib/slog"
+	"time"
+)
+
+const (
+	defaultAcceptErrorCooldownDuration = time.Second
+	defaultUpstreamNetwork             = "tcp"
+	defaultListenNetwork               = "tcp"
+	defaultListenAddress               = "0.0.0.0:4321"
+	defaultMaxConnectionsPerClient     = 10
+)
+
+var NotImplementedError = errors.New("not implemented")
+
+// TODO FIXME insecure
+var anonymousTestClientID = core.ClientID{Namespace: "test", Key: "anonymous"}
+
+type Config struct {
+	ListenNetwork           string
+	ListenAddress           string
+	Upstreams               []core.Upstream
+	MaxConnectionsPerClient int64
+}
+
+func (c *Config) Validate() error {
+	if len(c.Upstreams) == 0 {
+		return errors.New("server must be configured with 1 or more upstreams")
+	}
+	return nil
+}
+
+func makeClientReserverFromConfig(cfg *Config) (forwarder.ClientReserver, error) {
+	var reserver forwarder.ClientReserver
+	if cfg.MaxConnectionsPerClient > 0 {
+		reserver = limiter.NewUniformlyBoundedClientReserver(cfg.MaxConnectionsPerClient)
+	} else {
+		reserver = limiter.UnboundedClientReserver{}
+	}
+	return reserver, nil
+}
+
+func makeAuthorizerFromConfig(cfg *Config) (forwarder.Authorizer, error) {
+	// TODO FIXME begin placeholder demo authorization config
+	urGroup := authz.Group{Key: "ur"}
+	urUpstreamGroup := authz.UpstreamGroup{Key: "ur"}
+	authzCfg := authz.Config{
+		GroupsByClientID: map[core.ClientID][]authz.Group{
+			anonymousTestClientID: {urGroup},
+		},
+		UpstreamGroupsByGroup: map[authz.Group][]authz.UpstreamGroup{
+			urGroup: {urUpstreamGroup},
+		},
+		UpstreamsByUpstreamGroup: map[authz.UpstreamGroup]core.UpstreamSet{
+			urUpstreamGroup: core.NewUpstreamSet(cfg.Upstreams...),
+		},
+	}
+	// TODO FIXME end placeholder demo authorization config
+	return authz.NewStaticAuthorizer(authzCfg), nil
+}
+
+// IdiotDialer attempts to dial an arbitrary candidate and gives up if that fails.
+// This is a placeholder implementation with various issues:
+// - no timeout
+// - it doesn't attempt to balance load
+// - it doesn't try alternative upstreams if one attempt fails
+// - it doesn't learn anything
+type IdiotDialer struct{}
+
+func (d IdiotDialer) DialBestUpstream(ctx context.Context, candidates core.UpstreamSet) (core.Upstream, forwarder.DuplexConn, error) {
+	for c := range candidates {
+		conn, err := net.Dial(c.Network, c.Address)
+		if err != nil {
+			return core.Upstream{}, nil, err
+		}
+		switch upstreamConn := conn.(type) {
+		case *net.TCPConn:
+			return c, upstreamConn, nil
+		default:
+			_ = conn.Close()
+			break
+		}
+	}
+	return core.Upstream{}, nil, errors.New("idiot dialer failed to dial")
+}
+
+func makeDialerFromConfig(cfg *Config) (forwarder.BestUpstreamDialer, error) {
+	// TODO FIXME replace with something better
+	return IdiotDialer{}, nil
+}
+
+func makeForwarderFromConfig(cfg *Config) (forwarder.Forwarder, error) {
+	// TODO implement something more robust with timeouts
+	return forwarder.MediocreForwarder{}, nil
+}
+
+func coerceIntoAuthenticatedConn(logger slog.Logger, conn net.Conn) (forwarder.AuthenticatedConn, error) {
+	var authenticatedClientConn forwarder.AuthenticatedConn = nil
+	switch cc := conn.(type) {
+	case *tls.Conn:
+		authenticatedClientConn = &authn.AuthenticatedTLSConn{Conn: cc}
+	case *net.TCPConn:
+		logger.Warn(&slog.LogRecord{Msg: "using TCP connection to client, this is insecure"})
+		authenticatedClientConn = &authn.InsecureTCPConn{
+			TCPConn:  cc,
+			ClientID: anonymousTestClientID,
+		}
+	default:
+		return nil, NotImplementedError
+	}
+	return authenticatedClientConn, nil
+}
+
+func serve(logger slog.Logger, cfg *Config) error {
+	// Wire together the forwarder.Server
+
+	reserver, err := makeClientReserverFromConfig(cfg)
+	if err != nil {
+		logger.Error(&slog.LogRecord{Msg: "Client rate-limiter error", Error: err})
+		return err
+	}
+
+	authorizer, err := makeAuthorizerFromConfig(cfg)
+	if err != nil {
+		logger.Error(&slog.LogRecord{Msg: "Authorization configuration error", Error: err})
+		return err
+	}
+
+	dialer, err := makeDialerFromConfig(cfg)
+	if err != nil {
+		logger.Error(&slog.LogRecord{Msg: "Dialer configuration error", Error: err})
+		return err
+	}
+
+	fwder, err := makeForwarderFromConfig(cfg)
+	if err != nil {
+		logger.Error(&slog.LogRecord{Msg: "Forwarder configuration error", Error: err})
+		return err
+	}
+
+	s := &forwarder.Server{
+		Logger:     logger,
+		Reserver:   reserver,
+		Authorizer: authorizer,
+		Dialer:     dialer,
+		Forwarder:  fwder,
+	}
+
+	listener, err := net.Listen(cfg.ListenNetwork, cfg.ListenAddress)
+	if err != nil {
+		msg := fmt.Sprintf("Listen error with network: %s address: %s", cfg.ListenNetwork, cfg.ListenAddress)
+		logger.Error(&slog.LogRecord{Msg: msg, Error: err})
+		return err
+	}
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	// TODO graceful shutdown upon receiving interrupt
+	// - stop accepting new connections
+	// - wait for currently forwarded connections to terminate (hard cut off after timeout?)
+	// - stop healthcheck probes of upstreams (if applicable)
+
+	logger.Info(&slog.LogRecord{Msg: fmt.Sprintf("listening on network: %s address: %s", cfg.ListenNetwork, cfg.ListenAddress)})
+	for {
+		// TODO replace placeholder implementation: accept mTLS instead of TCP.
+		clientConn, err := listener.Accept()
+		if err != nil {
+			logger.Error(&slog.LogRecord{Msg: "listener.Accept error", Error: err})
+			time.Sleep(defaultAcceptErrorCooldownDuration)
+			continue
+		}
+		authenticatedClientConn, err := coerceIntoAuthenticatedConn(logger, clientConn)
+		if err != nil {
+			_ = clientConn.Close()
+			return err
+		}
+		// Handle is responsible for closing authenticatedClientConn
+		ctx := context.Background() // TODO consider adding cancel
+		go s.Handle(ctx, authenticatedClientConn)
+	}
+	// Unreachable.
+}

--- a/cmd/tcplb/server.go
+++ b/cmd/tcplb/server.go
@@ -170,12 +170,8 @@ func serve(logger slog.Logger, cfg *Config) error {
 		Reserver: reserver,
 		Inner:    authzHandler,
 	}
-	recovererHandler := &forwarder.RecovererHandler{
-		Logger: logger,
-		Inner:  rateLimitingHandler,
-	}
 	baseHandler := &forwarder.ConnCloserHandler{
-		Inner: recovererHandler,
+		Inner: rateLimitingHandler,
 	}
 
 	listener, err := net.Listen(cfg.ListenNetwork, cfg.ListenAddress)

--- a/lib/authn/authn.go
+++ b/lib/authn/authn.go
@@ -1,0 +1,84 @@
+package authn
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"net"
+	"tcplb/lib/core"
+)
+
+const (
+	DefaultNamespace = "CommonName"
+)
+
+var NoVerifiedChainError = errors.New("authentication failure - no verified chain")
+var InvalidClientIDError = errors.New("authentication failure - invalid client id")
+
+// ExtractCanonicalClientID attempts to extract a canonical ClientID from the given
+// verifiedChains, which are assumed to be arranged as per crypto/tls documentation.
+//
+// The CommonName attribute of the leaf certificate Subject of the 0-th chain is used
+// to determine the canonical ClientID.
+//
+// In the following circumstances, extraction fails, and a NoVerifiedChainError error
+// is returned:
+// - zero chains are given
+// - the 0th chain does not contain a certificate in position 0.
+//
+// In the following circumstances, extraction fails, and a InvalidClientIDError error
+// is returned:
+// - the 0th certificate in the 0th chain has an empty-string value for Subject CommonName
+func ExtractCanonicalClientID(verifiedChains [][]*x509.Certificate) (core.ClientID, error) {
+	if len(verifiedChains) == 0 {
+		return core.ClientID{}, NoVerifiedChainError
+	}
+	if len(verifiedChains[0]) == 0 {
+		return core.ClientID{}, NoVerifiedChainError
+	}
+	leafPeerCert := verifiedChains[0][0]
+	if leafPeerCert == nil {
+		return core.ClientID{}, NoVerifiedChainError
+	}
+	key := leafPeerCert.Subject.CommonName
+	if key == "" {
+		return core.ClientID{}, InvalidClientIDError
+	}
+	clientID := core.ClientID{
+		Namespace: DefaultNamespace,
+		Key:       key,
+	}
+	return clientID, nil
+}
+
+// AuthenticatedTLSConn wraps a tls.Conn and exposes a GetClientID method
+// that can be used to extract the canonical ClientID of the peer.
+//
+// Multiple goroutines may invoke methods on an AuthenticatedTLSConn
+// simultaneously.
+//
+// Beware: despite the interface name, it is the responsibility of whoever
+// established the tls.Conn to ensure peer authentication is required and
+// occurs successfully during the TLS handshake.
+type AuthenticatedTLSConn struct {
+	*tls.Conn
+}
+
+// GetClientID attempts to extract the canonical ClientID representing
+// the authenticated peer at the other side of an established TLS
+// connection. See ExtractCanonicalClientID for details.
+func (c *AuthenticatedTLSConn) GetClientID() (core.ClientID, error) {
+	return ExtractCanonicalClientID(c.ConnectionState().VerifiedChains)
+}
+
+// InsecureTCPConn is not secure, and shouldn't be used outside of testing.
+// It can be used to make a TCP Connection with a client appear as if it
+// is an authenticated connection.
+type InsecureTCPConn struct {
+	*net.TCPConn
+	ClientID core.ClientID
+}
+
+func (c *InsecureTCPConn) GetClientID() (core.ClientID, error) {
+	return c.ClientID, nil
+}

--- a/lib/authn/authn_test.go
+++ b/lib/authn/authn_test.go
@@ -1,0 +1,65 @@
+package authn
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"github.com/stretchr/testify/require"
+	"tcplb/lib/core"
+	"testing"
+)
+
+func TestExtractCanonicalClientIDErrorsIfNilChains(t *testing.T) {
+	_, err := ExtractCanonicalClientID(nil)
+	require.ErrorIs(t, err, NoVerifiedChainError)
+}
+
+func TestExtractCanonicalClientIDErrorsIfZerothChainIsNil(t *testing.T) {
+	chains := [][]*x509.Certificate{
+		nil,
+	}
+	_, err := ExtractCanonicalClientID(chains)
+	require.ErrorIs(t, err, NoVerifiedChainError)
+}
+
+func TestExtractCanonicalClientIDErrorsIfZerothChainIsEmpty(t *testing.T) {
+	chains := [][]*x509.Certificate{
+		{},
+	}
+	_, err := ExtractCanonicalClientID(chains)
+	require.ErrorIs(t, err, NoVerifiedChainError)
+}
+
+func TestExtractCanonicalClientIDErrorsIfZerothCertInZerothChainHasBlankCommonName(t *testing.T) {
+	leaf := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "",
+		},
+	}
+	chains := [][]*x509.Certificate{
+		{leaf},
+	}
+	_, err := ExtractCanonicalClientID(chains)
+	require.ErrorIs(t, err, InvalidClientIDError)
+}
+
+func TestExtractCanonicalClientIDCanSucceed(t *testing.T) {
+	exampleID := "some test name"
+
+	leaf := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: exampleID,
+		},
+	}
+	chains := [][]*x509.Certificate{
+		{leaf},
+	}
+	clientId, err := ExtractCanonicalClientID(chains)
+
+	expectedClientId := core.ClientID{
+		Namespace: DefaultNamespace,
+		Key:       exampleID,
+	}
+
+	require.NoError(t, err)
+	require.Equal(t, expectedClientId, clientId)
+}

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -1,0 +1,32 @@
+package errors
+
+import "fmt"
+
+type AggregateError struct {
+	Errors []error
+}
+
+func (e *AggregateError) Error() string {
+	if e == nil {
+		return fmt.Sprintf("AggregateError: nil")
+	}
+	return fmt.Sprintf("AggregateError: %v", e.Errors)
+}
+
+// AggregateErrorFromChannel gathers non-nil error values (if any)
+// from the given channel and bundles them into an AggregateError.
+// The channel must contain some finite number of errors and be closed.
+// If no errors are read from the channel, nil is returned.
+func AggregateErrorFromChannel(errorchan <-chan error) error {
+	errs := make([]error, 0)
+	for err := range errorchan {
+		if err == nil {
+			continue
+		}
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return &AggregateError{Errors: errs}
+	}
+	return nil
+}

--- a/lib/forwarder/forwarder.go
+++ b/lib/forwarder/forwarder.go
@@ -1,0 +1,43 @@
+package forwarder
+
+import (
+	"context"
+	"io"
+	"sync"
+	"tcplb/lib/errors"
+)
+
+// MediocreForwarder is a implementation of the Forward operation.
+// This is a placeholder implementation that lacks robustness.
+type MediocreForwarder struct{}
+
+func (f MediocreForwarder) Forward(ctx context.Context, clientConn, upstreamConn DuplexConn) error {
+	// Caller is responsible for closing both DuplexConns, not us.
+	out := make(chan error, 2)
+	wg := sync.WaitGroup{}
+
+	copy := func(dst, src DuplexConn, out chan<- error) {
+		defer wg.Done()
+		// TODO FIXME add an idle timeout here that detects if neither
+		// of the two directions of copying have made any progress in
+		// some time window.
+		// TODO FIXME also honour cancellation by ctx
+		_, err := io.Copy(dst, src)
+		_ = dst.CloseWrite() // Inform peer at dst end that we're done writing.
+		out <- err
+	}
+
+	wg.Add(1)
+	go copy(upstreamConn, clientConn, out)
+	wg.Add(1)
+	go copy(clientConn, upstreamConn, out)
+
+	// Note that if upstream and client keep talking to each other without ever
+	// closing their connection, we may block here forever, while one or both
+	// goroutines copy application data. This is a feature, as this server is
+	// doing useful work.
+	wg.Wait()
+	close(out)
+
+	return errors.AggregateErrorFromChannel(out)
+}

--- a/lib/forwarder/handler.go
+++ b/lib/forwarder/handler.go
@@ -8,6 +8,10 @@ import (
 	"tcplb/lib/slog"
 )
 
+const (
+	RecovererUnexpectedPanicMessage = "RecovererHandler: Unexpected panic!"
+)
+
 type clientIdContextKeyType struct{}
 type upstreamsContextKeyType struct{}
 
@@ -70,7 +74,7 @@ func (h *RecovererHandler) Handle(ctx context.Context, conn AuthenticatedConn) {
 			return
 		}
 		h.Logger.Error(&slog.LogRecord{
-			Msg:        "RecovererHandler: Unexpected panic!",
+			Msg:        RecovererUnexpectedPanicMessage,
 			Details:    panicValue,
 			StackTrace: string(debug.Stack()),
 		})

--- a/lib/forwarder/handler.go
+++ b/lib/forwarder/handler.go
@@ -1,0 +1,206 @@
+package forwarder
+
+import (
+	"context"
+	"runtime/debug"
+	"tcplb/lib/core"
+	"tcplb/lib/limiter"
+	"tcplb/lib/slog"
+)
+
+type clientIdContextKeyType struct{}
+type upstreamsContextKeyType struct{}
+
+var clientIdContextKey = clientIdContextKeyType{}
+var upstreamContextKey = upstreamsContextKeyType{}
+
+func NewContextWithClientID(parent context.Context, clientID core.ClientID) context.Context {
+	return context.WithValue(parent, clientIdContextKey, clientID)
+}
+
+func ClientIDFromContext(ctx context.Context) (core.ClientID, bool) {
+	clientID, ok := ctx.Value(clientIdContextKey).(core.ClientID)
+	return clientID, ok
+}
+
+func NewContextWithUpstreams(parent context.Context, upstreams core.UpstreamSet) context.Context {
+	return context.WithValue(parent, upstreamContextKey, upstreams)
+}
+
+func UpstreamsFromContext(ctx context.Context) (core.UpstreamSet, bool) {
+	upstreams, ok := ctx.Value(upstreamContextKey).(core.UpstreamSet)
+	return upstreams, ok
+}
+
+type Handler interface {
+	// Handle accepts the given AuthenticatedConn from the client.
+	Handle(ctx context.Context, conn AuthenticatedConn)
+}
+
+// ConnCloserHandler is a handler that closes the client connection
+// after the Inner handler has finished handling it. It should be the
+// base Handler in the stack.
+type ConnCloserHandler struct {
+	Inner Handler
+}
+
+func (h *ConnCloserHandler) Handle(ctx context.Context, conn AuthenticatedConn) {
+	defer func() {
+		// If there are errors closing the client connection, it is
+		// likely due to client or network. Ignore them.
+		_ = conn.Close()
+	}()
+	h.Inner.Handle(ctx, conn)
+}
+
+var _ Handler = (*ConnCloserHandler)(nil) // type check
+
+// RecovererHandler is a handler that recovers from panics raised by the
+// Inner handler (if any) and logs an error to the given Logger.
+type RecovererHandler struct {
+	Logger slog.Logger
+	Inner  Handler
+}
+
+func (h *RecovererHandler) Handle(ctx context.Context, conn AuthenticatedConn) {
+	defer func() {
+		panicValue := recover()
+		if panicValue == nil {
+			// Either not panicking or someone called panic(nil). Assume former.
+			return
+		}
+		h.Logger.Error(&slog.LogRecord{
+			Msg:        "RecovererHandler: Unexpected panic!",
+			Details:    panicValue,
+			StackTrace: string(debug.Stack()),
+		})
+	}()
+	h.Inner.Handle(ctx, conn)
+}
+
+var _ Handler = (*RecovererHandler)(nil) // type check
+
+// RateLimitingHandler is a handler that only allows the Inner handler to
+// Handle the connection if a reservation can be obtained for the ClientID.
+// A ClientID is expected to be found in the context.
+type RateLimitingHandler struct {
+	Logger   slog.Logger
+	Reserver ClientReserver
+	Inner    Handler
+}
+
+func (h *RateLimitingHandler) Handle(ctx context.Context, conn AuthenticatedConn) {
+	clientID, ok := ClientIDFromContext(ctx)
+	if !ok {
+		h.Logger.Error(&slog.LogRecord{Msg: "RateLimitingHandler: Failed to get ClientID from context"})
+		return
+	}
+
+	// Clients are subject to rate-limiting.
+	err := h.Reserver.TryReserve(ctx, clientID)
+	if err != nil {
+		switch err {
+		// TODO: refactor to break dep on package lib/limiter
+		case limiter.MaxReservationsExceeded:
+			h.Logger.Warn(&slog.LogRecord{Msg: "RateLimitingHandler: Client rate limited", ClientID: &clientID})
+		default:
+			h.Logger.Error(&slog.LogRecord{Msg: "RateLimitingHandler: TryReserve error", ClientID: &clientID, Error: err})
+		}
+		return
+	}
+	defer func() {
+		err := h.Reserver.ReleaseReservation(ctx, clientID)
+		if err != nil {
+			h.Logger.Error(&slog.LogRecord{Msg: "RateLimitingHandler: ReleaseReservation error", ClientID: &clientID, Error: err})
+		}
+	}()
+
+	h.Inner.Handle(ctx, conn)
+}
+
+var _ Handler = (*RateLimitingHandler)(nil) // type check
+
+// AuthorizedUpstreamsHandler is a handler that determines which upstreams
+// the client connection is authorized to forward to. If the client is
+// authorized to connect to one or more upstreams, an UpstreamSet is stored
+// in the child context passed to the Inner Handler, and can be extracted
+// with UpstreamsFromContext.
+type AuthorizedUpstreamsHandler struct {
+	Logger     slog.Logger
+	Authorizer Authorizer
+	Inner      Handler
+}
+
+func (h *AuthorizedUpstreamsHandler) Handle(ctx context.Context, conn AuthenticatedConn) {
+	clientID, ok := ClientIDFromContext(ctx)
+	if !ok {
+		h.Logger.Error(&slog.LogRecord{Msg: "AuthorizedUpstreamsHandler: Failed to get ClientID from context"})
+		return
+	}
+
+	// Clients are only authorized to forward to certain upstreams.
+	authzUpstreams, err := h.Authorizer.AuthorizedUpstreams(ctx, clientID)
+	if err != nil {
+		h.Logger.Error(&slog.LogRecord{Msg: "AuthorizedUpstreamsHandler: AuthorizedUpstreams error", ClientID: &clientID, Error: err})
+		return
+	}
+	if len(authzUpstreams) == 0 {
+		h.Logger.Warn(&slog.LogRecord{Msg: "Client not authorized for forwarding", ClientID: &clientID, Error: err})
+		return
+	}
+
+	childCtx := NewContextWithUpstreams(ctx, authzUpstreams)
+
+	h.Inner.Handle(childCtx, conn)
+}
+
+var _ Handler = (*AuthorizedUpstreamsHandler)(nil) // type check
+
+// ForwardingHandler is the terminal handler that dials the best upstream to
+// serve the client connection, then forwards the client connection to that upstream.
+// It expects to find clientID and upstreams (the set of candidate upstreams to
+// consider forwarding to) in the given context.
+type ForwardingHandler struct {
+	Logger    slog.Logger
+	Dialer    BestUpstreamDialer
+	Forwarder Forwarder
+}
+
+func (h *ForwardingHandler) Handle(ctx context.Context, conn AuthenticatedConn) {
+	clientID, ok := ClientIDFromContext(ctx)
+	if !ok {
+		h.Logger.Error(&slog.LogRecord{Msg: "ForwardingHandler: Failed to get ClientID from context"})
+		return
+	}
+	candidateUpstreams, ok := UpstreamsFromContext(ctx)
+	if !ok {
+		h.Logger.Error(&slog.LogRecord{Msg: "ForwardingHandler: Failed to get candidate Upstreams from context"})
+		return
+	}
+	upstream, upstreamConn, err := h.Dialer.DialBestUpstream(ctx, candidateUpstreams)
+	if err != nil {
+		// TODO many failure modes end up here. Improve logging to help the operator triage.
+		h.Logger.Error(&slog.LogRecord{Msg: "ForwardingHandler: DialBestUpstream error", ClientID: &clientID, Error: err})
+		return
+	}
+	defer func() {
+		// If there are errors closing the upstream connection, it is
+		// likely due to upstream or network. Ignore them.
+		_ = upstreamConn.Close()
+	}()
+	h.Logger.Info(&slog.LogRecord{Msg: "ForwardingHandler: Attempting Forward", ClientID: &clientID, Upstream: &upstream})
+	err = h.Forwarder.Forward(ctx, conn, upstreamConn)
+	if err != nil {
+		// TODO if upstreamConn is established successfully but later experiences an error that
+		// causes Forward to terminate abnormally, then arguably we could sense that here and
+		// lodge a HealthReport about that upstream.
+		// An alternative approach could be to handle it internally within the BestUpstreamDialer
+		// abstraction, which could wrap & instrument the returned upstreamConn to report health.
+
+		h.Logger.Error(&slog.LogRecord{Msg: "ForwardingHandler: Forward complete with error", ClientID: &clientID, Upstream: &upstream, Error: err})
+		return
+	}
+	h.Logger.Info(&slog.LogRecord{Msg: "ForwardingHandler: Forward complete", ClientID: &clientID, Upstream: &upstream})
+}
+
+var _ Handler = (*ForwardingHandler)(nil) // type check

--- a/lib/forwarder/handler_test.go
+++ b/lib/forwarder/handler_test.go
@@ -1,0 +1,97 @@
+package forwarder
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"tcplb/lib/core"
+	"tcplb/lib/slog"
+	"testing"
+)
+
+func TestClientIDFromContext(t *testing.T) {
+	parentCtx := context.Background()
+	c := core.ClientID{Namespace: "handler-test", Key: "a"}
+	childCtx := NewContextWithClientID(parentCtx, c)
+	cPrime, ok := ClientIDFromContext(childCtx)
+	require.True(t, ok)
+	require.Equal(t, c, cPrime)
+}
+
+func TestClientIDFromContextMissing(t *testing.T) {
+	ctx := context.Background()
+	_, ok := ClientIDFromContext(ctx)
+	require.False(t, ok)
+}
+
+func TestUpstreamsFromContext(t *testing.T) {
+	a := core.Upstream{Network: "handler-test", Address: "a"}
+	b := core.Upstream{Network: "handler-test", Address: "b"}
+	c := core.Upstream{Network: "handler-test", Address: "c"}
+	upstreams := core.NewUpstreamSet(a, b, c)
+
+	parentCtx := context.Background()
+	childCtx := NewContextWithUpstreams(parentCtx, upstreams)
+	upstreamsPrime, ok := UpstreamsFromContext(childCtx)
+	require.True(t, ok)
+	require.Equal(t, upstreams, upstreamsPrime)
+}
+
+func TestUpstreamsFromContextMissing(t *testing.T) {
+	ctx := context.Background()
+	_, ok := UpstreamsFromContext(ctx)
+	require.False(t, ok)
+}
+
+func TestClientIDAndUpstreamsFromContext(t *testing.T) {
+	// test that one context key doesn't overwrite the other one...
+
+	clientID := core.ClientID{Namespace: "handler-test", Key: "a"}
+
+	a := core.Upstream{Network: "handler-test", Address: "a"}
+	b := core.Upstream{Network: "handler-test", Address: "b"}
+	c := core.Upstream{Network: "handler-test", Address: "c"}
+	upstreams := core.NewUpstreamSet(a, b, c)
+
+	parentCtx := context.Background()
+
+	childCtx := NewContextWithUpstreams(
+		NewContextWithClientID(parentCtx, clientID),
+		upstreams)
+
+	clientIDPrime, ok := ClientIDFromContext(childCtx)
+	require.True(t, ok)
+	require.Equal(t, clientID, clientIDPrime)
+
+	upstreamsPrime, ok := UpstreamsFromContext(childCtx)
+	require.True(t, ok)
+	require.Equal(t, upstreams, upstreamsPrime)
+}
+
+// alwaysPanicHandler always panics when asked to Handle.
+type alwaysPanicHandler struct {
+	PanicValue string
+}
+
+func (h alwaysPanicHandler) Handle(ctx context.Context, conn AuthenticatedConn) {
+	panic(h.PanicValue)
+}
+
+func TestRecovererHandlerLogsPanics(t *testing.T) {
+	logger := &slog.RecordingLogger{}
+
+	h := &RecovererHandler{
+		Logger: logger,
+		Inner:  alwaysPanicHandler{PanicValue: "oh no!"},
+	}
+
+	ctx := context.Background()
+	var conn AuthenticatedConn
+
+	h.Handle(ctx, conn)
+
+	require.Len(t, logger.Events, 1)
+	event := logger.Events[0]
+	require.Equal(t, "error", event.Level)
+	require.Equal(t, "RecovererHandler: Unexpected panic!", event.Msg)
+	require.Equal(t, "oh no!", event.Details)
+}

--- a/lib/forwarder/server.go
+++ b/lib/forwarder/server.go
@@ -1,0 +1,189 @@
+package forwarder
+
+import (
+	"context"
+	"net"
+	"runtime/debug"
+	"tcplb/lib/core"
+	"tcplb/lib/limiter"
+	"tcplb/lib/slog"
+)
+
+// CloseWriter represents something that can CloseWrite.
+//
+// Notable implementations in the standard library include:
+// - net.TCPCOnn
+// - tls.Conn
+type CloseWriter interface {
+	CloseWrite() error // CloseWrite shuts down the writer side of a connection.
+}
+
+type DuplexConn interface {
+	net.Conn
+	CloseWriter
+}
+
+// AuthenticatedConn represents an established authenticated
+// connection to a client.
+type AuthenticatedConn interface {
+	net.Conn
+	CloseWriter
+
+	// GetClientID attempts to extract the canonical ClientID representing
+	// the identity of an authenticated peer.
+	GetClientID() (core.ClientID, error)
+}
+
+// ClientReserver represents an entity that can limit "reservations"
+// by clients, as an abstraction of client rate limiting.
+//
+// Multiple goroutines may invoke methods on a ClientReserver
+// simultaneously.
+type ClientReserver interface {
+	// TryReserve attempts to acquire a reservation for the given client.
+	// If the attempt succeeds, nil is returned.
+	// If no reservations are available, the attempt returns an error.
+	// This call does not block.
+	TryReserve(ctx context.Context, c core.ClientID) error
+
+	// ReleaseReservation releases a reservation that was previously acquired
+	// for the given ClientID c by TryReserve.
+	ReleaseReservation(ctx context.Context, c core.ClientID) error
+}
+
+// Authorizer abstracts an authorization policy that
+// controls which clients are allowed to forward connections to which upstreams.
+//
+// Multiple goroutines may invoke methods on an Authorizer simultaneously.
+type Authorizer interface {
+	// AuthorizedUpstreams returns an UpstreamSet of upstreams that the ClientID c
+	// is authorized to access. If c is not authorized to access any upstreams,
+	// implementations should return an empty UpstreamSet and nil.
+	AuthorizedUpstreams(ctx context.Context, c core.ClientID) (core.UpstreamSet, error)
+}
+
+// BestUpstreamDialer dials the best upstream out of a set of candidates.
+//
+// Multiple goroutines may invoke methods on a BestUpstreamDialer simultaneously.
+type BestUpstreamDialer interface {
+	// DialBestUpstream considers the given candidate upstreams and attempts to connect to
+	// the "best" one (implementation defined). If successful, the winning Upstream is
+	// returned alongside a DuplexConn to that upstream, and nil error.
+	//
+	// If error is nil, the caller is responsible for closing the returned DuplexConn
+	// once finished with it to avoid leaking resources.
+	DialBestUpstream(ctx context.Context, candidates core.UpstreamSet) (core.Upstream, DuplexConn, error)
+}
+
+// Forwarder copies data between a client DuplexConn and an upstream DuplexConn.
+//
+// Multiple goroutines may invoke methods on a Forwarder simultaneously.
+type Forwarder interface {
+	// Forward connects the clientConn and upstreamConn together, copying
+	// application data between the two.
+	//
+	// The Forward operation blocks until:
+	// - one of the two parties closes their end of the connection
+	// - one or both of the given connections encounters a serious error
+	// - the Forwarder implementation decides to stop forwarding
+	//
+	// In the event that the forwarding connection is terminated normally
+	// by one or both parties, a nil error is returned.
+	//
+	// Forward implementations must not Close the clientConn or upstreamConn.
+	// It may CloseWrite one or both of them.
+	Forward(ctx context.Context, clientConn, upstreamConn DuplexConn) error
+}
+
+type Server struct {
+	Logger     slog.Logger
+	Reserver   ClientReserver
+	Authorizer Authorizer
+	Dialer     BestUpstreamDialer
+	Forwarder  Forwarder
+}
+
+// Handle accepts the given AuthenticatedConn from the client and
+// attempts to forward it to a configured upstream.
+//
+// Handle is responsible for closing the given AuthenticatedConn.
+func (s *Server) Handle(ctx context.Context, conn AuthenticatedConn) {
+	defer func() {
+		// If there are errors closing the client connection, it is
+		// likely due to client or network. Ignore them.
+		_ = conn.Close()
+	}()
+	defer func() {
+		panicValue := recover()
+		if panicValue == nil {
+			// Either not panicking or someone called panic(nil). Assume former.
+			return
+		}
+		s.Logger.Error(&slog.LogRecord{
+			Msg:        "Unexpected panic!",
+			Details:    panicValue,
+			StackTrace: string(debug.Stack()),
+		})
+	}()
+
+	clientID, err := conn.GetClientID()
+	if err != nil {
+		s.Logger.Error(&slog.LogRecord{Msg: "Failed to get ClientID", Error: err})
+		return
+	}
+
+	// Clients are subject to rate-limiting.
+	err = s.Reserver.TryReserve(ctx, clientID)
+	if err != nil {
+		switch err {
+		// TODO: refactor to break dep on package lib/limiter
+		case limiter.MaxReservationsExceeded:
+			s.Logger.Warn(&slog.LogRecord{Msg: "Client rate limited", ClientID: &clientID})
+		default:
+			s.Logger.Error(&slog.LogRecord{Msg: "TryReserve error", ClientID: &clientID, Error: err})
+		}
+		return
+	}
+	defer func() {
+		err := s.Reserver.ReleaseReservation(ctx, clientID)
+		if err != nil {
+			s.Logger.Error(&slog.LogRecord{Msg: "ReleaseReservation error", ClientID: &clientID, Error: err})
+		}
+	}()
+
+	// Clients are only authorized to forward to certain upstreams.
+	authzUpstreams, err := s.Authorizer.AuthorizedUpstreams(ctx, clientID)
+	if err != nil {
+		s.Logger.Error(&slog.LogRecord{Msg: "AuthorizedUpstreams error", ClientID: &clientID, Error: err})
+		return
+	}
+	if len(authzUpstreams) == 0 {
+		s.Logger.Warn(&slog.LogRecord{Msg: "Client not authorized for forwarding", ClientID: &clientID, Error: err})
+		return
+	}
+
+	upstream, upstreamConn, err := s.Dialer.DialBestUpstream(ctx, authzUpstreams)
+	if err != nil {
+		// TODO many failure modes end up here. Improve logging to help the operator triage.
+		s.Logger.Error(&slog.LogRecord{Msg: "DialBestUpstream error", ClientID: &clientID, Error: err})
+		return
+	}
+	defer func() {
+		// If there are errors closing the upstream connection, it is
+		// likely due to upstream or network. Ignore them.
+		_ = upstreamConn.Close()
+	}()
+	s.Logger.Info(&slog.LogRecord{Msg: "Attempting Forward", ClientID: &clientID, Upstream: &upstream})
+	err = s.Forwarder.Forward(ctx, conn, upstreamConn)
+	if err != nil {
+		// TODO if upstreamConn is established successfully but later experiences an error that
+		// causes Forward to terminate abnormally, then arguably we could sense that here and
+		// lodge a HealthReport about that upstream.
+		// An alternative approach could be to handle it internally within the BestUpstreamDialer
+		// abstraction, which could wrap & instrument the returned upstreamConn to report health.
+
+		s.Logger.Error(&slog.LogRecord{Msg: "Forward complete with error", ClientID: &clientID, Upstream: &upstream, Error: err})
+		return
+	}
+	s.Logger.Info(&slog.LogRecord{Msg: "Forward complete", ClientID: &clientID, Upstream: &upstream})
+}

--- a/lib/forwarder/server.go
+++ b/lib/forwarder/server.go
@@ -3,10 +3,7 @@ package forwarder
 import (
 	"context"
 	"net"
-	"runtime/debug"
 	"tcplb/lib/core"
-	"tcplb/lib/limiter"
-	"tcplb/lib/slog"
 )
 
 // CloseWriter represents something that can CloseWrite.
@@ -93,97 +90,4 @@ type Forwarder interface {
 	// Forward implementations must not Close the clientConn or upstreamConn.
 	// It may CloseWrite one or both of them.
 	Forward(ctx context.Context, clientConn, upstreamConn DuplexConn) error
-}
-
-type Server struct {
-	Logger     slog.Logger
-	Reserver   ClientReserver
-	Authorizer Authorizer
-	Dialer     BestUpstreamDialer
-	Forwarder  Forwarder
-}
-
-// Handle accepts the given AuthenticatedConn from the client and
-// attempts to forward it to a configured upstream.
-//
-// Handle is responsible for closing the given AuthenticatedConn.
-func (s *Server) Handle(ctx context.Context, conn AuthenticatedConn) {
-	defer func() {
-		// If there are errors closing the client connection, it is
-		// likely due to client or network. Ignore them.
-		_ = conn.Close()
-	}()
-	defer func() {
-		panicValue := recover()
-		if panicValue == nil {
-			// Either not panicking or someone called panic(nil). Assume former.
-			return
-		}
-		s.Logger.Error(&slog.LogRecord{
-			Msg:        "Unexpected panic!",
-			Details:    panicValue,
-			StackTrace: string(debug.Stack()),
-		})
-	}()
-
-	clientID, err := conn.GetClientID()
-	if err != nil {
-		s.Logger.Error(&slog.LogRecord{Msg: "Failed to get ClientID", Error: err})
-		return
-	}
-
-	// Clients are subject to rate-limiting.
-	err = s.Reserver.TryReserve(ctx, clientID)
-	if err != nil {
-		switch err {
-		// TODO: refactor to break dep on package lib/limiter
-		case limiter.MaxReservationsExceeded:
-			s.Logger.Warn(&slog.LogRecord{Msg: "Client rate limited", ClientID: &clientID})
-		default:
-			s.Logger.Error(&slog.LogRecord{Msg: "TryReserve error", ClientID: &clientID, Error: err})
-		}
-		return
-	}
-	defer func() {
-		err := s.Reserver.ReleaseReservation(ctx, clientID)
-		if err != nil {
-			s.Logger.Error(&slog.LogRecord{Msg: "ReleaseReservation error", ClientID: &clientID, Error: err})
-		}
-	}()
-
-	// Clients are only authorized to forward to certain upstreams.
-	authzUpstreams, err := s.Authorizer.AuthorizedUpstreams(ctx, clientID)
-	if err != nil {
-		s.Logger.Error(&slog.LogRecord{Msg: "AuthorizedUpstreams error", ClientID: &clientID, Error: err})
-		return
-	}
-	if len(authzUpstreams) == 0 {
-		s.Logger.Warn(&slog.LogRecord{Msg: "Client not authorized for forwarding", ClientID: &clientID, Error: err})
-		return
-	}
-
-	upstream, upstreamConn, err := s.Dialer.DialBestUpstream(ctx, authzUpstreams)
-	if err != nil {
-		// TODO many failure modes end up here. Improve logging to help the operator triage.
-		s.Logger.Error(&slog.LogRecord{Msg: "DialBestUpstream error", ClientID: &clientID, Error: err})
-		return
-	}
-	defer func() {
-		// If there are errors closing the upstream connection, it is
-		// likely due to upstream or network. Ignore them.
-		_ = upstreamConn.Close()
-	}()
-	s.Logger.Info(&slog.LogRecord{Msg: "Attempting Forward", ClientID: &clientID, Upstream: &upstream})
-	err = s.Forwarder.Forward(ctx, conn, upstreamConn)
-	if err != nil {
-		// TODO if upstreamConn is established successfully but later experiences an error that
-		// causes Forward to terminate abnormally, then arguably we could sense that here and
-		// lodge a HealthReport about that upstream.
-		// An alternative approach could be to handle it internally within the BestUpstreamDialer
-		// abstraction, which could wrap & instrument the returned upstreamConn to report health.
-
-		s.Logger.Error(&slog.LogRecord{Msg: "Forward complete with error", ClientID: &clientID, Upstream: &upstream, Error: err})
-		return
-	}
-	s.Logger.Info(&slog.LogRecord{Msg: "Forward complete", ClientID: &clientID, Upstream: &upstream})
 }

--- a/lib/slog/slog.go
+++ b/lib/slog/slog.go
@@ -1,0 +1,94 @@
+// Package slog is a logger interface offering a uniformly unpleasant
+// and wearying experience for application developers, users and operators.
+//
+// TODO replace this entirely with something else. Maybe zerolog?
+package slog
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"tcplb/lib/core"
+)
+
+// LogRecord holds data for a single server log record.
+type LogRecord struct {
+	Msg        string         `json:"msg,omitempty"`        // Msg is an optional log message
+	Error      error          `json:"error,omitempty"`      // Error is an optional error
+	Details    any            `json:"details,omitempty"`    // Details are optional details
+	StackTrace string         `json:"stacktrace,omitempty"` // StackTrace is optional stack trace
+	ClientID   *core.ClientID `json:"clientid,omitempty"`   // ClientID is optional id of client, if known.
+	Upstream   *core.Upstream `json:"upstream,omitempty"`   // Upstream is optional upstream, if known.
+}
+
+// Logger is an abstract log interface for the server.
+//
+// Multiple goroutines may invoke methods on a Logger simultaneously.
+type Logger interface {
+	Info(record *LogRecord)
+	Warn(record *LogRecord)
+	Error(record *LogRecord)
+}
+
+// TODO make the log output less awful to read by humans and machines.
+type stdlibLogShim struct{}
+
+type errorPayload struct {
+	Type  string `json:"type,omitempty"`  // Type is the error type
+	Error string `json:"error,omitempty"` // Error is the error message
+}
+
+func asErrorPayload(err error) *errorPayload {
+	if err == nil {
+		return nil
+	}
+	return &errorPayload{
+		Type:  fmt.Sprintf("%T", err),
+		Error: err.Error(),
+	}
+}
+
+type recordPayload struct {
+	Msg        string         `json:"msg,omitempty"`        // Msg is an optional log message
+	Error      *errorPayload  `json:"error,omitempty"`      // Error is an optional error
+	Details    any            `json:"details,omitempty"`    // Details are optional details
+	StackTrace string         `json:"stacktrace,omitempty"` // StackTrace is optional stack trace
+	ClientID   *core.ClientID `json:"clientid,omitempty"`   // ClientID is optional id of client, if known.
+	Upstream   *core.Upstream `json:"upstream,omitempty"`   // Upstream is optional upstream, if known.
+	Level      string         `json:"level,omitempty"`
+}
+
+func logRecordAsSemiJSON(level string, record *LogRecord) {
+	var payload recordPayload
+	payload.Level = level
+	if record != nil {
+		payload.Msg = record.Msg
+		payload.Error = asErrorPayload(record.Error)
+		payload.Details = record.Details
+		payload.StackTrace = record.StackTrace
+		payload.ClientID = record.ClientID
+		payload.Upstream = record.Upstream
+	}
+
+	data, _ := json.Marshal(&payload)
+
+	// TODO put the timestamps in the JSON as well.
+	log.Println(string(data))
+}
+
+func (s *stdlibLogShim) Info(record *LogRecord) {
+	logRecordAsSemiJSON("info", record)
+}
+
+func (s *stdlibLogShim) Warn(record *LogRecord) {
+	logRecordAsSemiJSON("warn", record)
+}
+
+func (s *stdlibLogShim) Error(record *LogRecord) {
+	logRecordAsSemiJSON("error", record)
+}
+
+// GetDefaultLogger returns the default Logger.
+func GetDefaultLogger() Logger {
+	return &stdlibLogShim{}
+}

--- a/lib/slog/slog.go
+++ b/lib/slog/slog.go
@@ -11,6 +11,12 @@ import (
 	"tcplb/lib/core"
 )
 
+const (
+	InfoLevel  = "info"
+	WarnLevel  = "warn"
+	ErrorLevel = "error"
+)
+
 // LogRecord holds data for a single server log record.
 type LogRecord struct {
 	Msg        string         `json:"msg,omitempty"`        // Msg is an optional log message
@@ -77,15 +83,15 @@ func logRecordAsSemiJSON(level string, record *LogRecord) {
 }
 
 func (s *stdlibLogShim) Info(record *LogRecord) {
-	logRecordAsSemiJSON("info", record)
+	logRecordAsSemiJSON(InfoLevel, record)
 }
 
 func (s *stdlibLogShim) Warn(record *LogRecord) {
-	logRecordAsSemiJSON("warn", record)
+	logRecordAsSemiJSON(WarnLevel, record)
 }
 
 func (s *stdlibLogShim) Error(record *LogRecord) {
-	logRecordAsSemiJSON("error", record)
+	logRecordAsSemiJSON(ErrorLevel, record)
 }
 
 // GetDefaultLogger returns the default Logger.
@@ -105,15 +111,15 @@ type Event struct {
 }
 
 func (l *RecordingLogger) Info(record *LogRecord) {
-	l.Events = append(l.Events, Event{Level: "info", LogRecord: record})
+	l.Events = append(l.Events, Event{Level: InfoLevel, LogRecord: record})
 }
 
 func (l *RecordingLogger) Warn(record *LogRecord) {
-	l.Events = append(l.Events, Event{Level: "warn", LogRecord: record})
+	l.Events = append(l.Events, Event{Level: WarnLevel, LogRecord: record})
 }
 
 func (l *RecordingLogger) Error(record *LogRecord) {
-	l.Events = append(l.Events, Event{Level: "error", LogRecord: record})
+	l.Events = append(l.Events, Event{Level: ErrorLevel, LogRecord: record})
 }
 
 var _ Logger = (*RecordingLogger)(nil) // type check

--- a/lib/slog/slog.go
+++ b/lib/slog/slog.go
@@ -92,3 +92,28 @@ func (s *stdlibLogShim) Error(record *LogRecord) {
 func GetDefaultLogger() Logger {
 	return &stdlibLogShim{}
 }
+
+// RecordingLogger captures all logged events in memory.
+// It is designed for use as a test fixture.
+type RecordingLogger struct {
+	Events []Event
+}
+
+type Event struct {
+	Level string
+	*LogRecord
+}
+
+func (l *RecordingLogger) Info(record *LogRecord) {
+	l.Events = append(l.Events, Event{Level: "info", LogRecord: record})
+}
+
+func (l *RecordingLogger) Warn(record *LogRecord) {
+	l.Events = append(l.Events, Event{Level: "warn", LogRecord: record})
+}
+
+func (l *RecordingLogger) Error(record *LogRecord) {
+	l.Events = append(l.Events, Event{Level: "error", LogRecord: record})
+}
+
+var _ Logger = (*RecordingLogger)(nil) // type check


### PR DESCRIPTION
adds basic tcplb application with some features:

- can listen and accept TCP connections (insecure!)
- some options are configurable with flags
- configurable client rate limiting
- hardcoded "authentication" (insecure!)
- hardcoded authorization policy (insecure!)
- placeholder idiotic dialing logic
- placeholder non-robust logic to forward application data

adds libraries:

- lib/authn -- adapters to get the ClientID from a client connection
- lib/forwarder/handler -- various "handlers" that compose to serve a single client connection
- lib/forwarder/server -- interfaces used by various handlers
- lib/forwarder/forwarder -- forward application data between client and upstream (placeholder)
- lib/slog -- server logger interface
- lib/errors -- error utilities

out of scope of this PR, but planned for follow-up PRs:

- replace TCP server: accept secure TLS connections using mTLS
- replace dialing logic: prefer dialing an upstream with fewest connections, handle failures, timeouts
- robustly handle timeouts when dialing & forwarding application data
- basic automated test of entire load balancer application
- monitor upstream health & avoid forwarding to unhealthy upstreams

