### PR TITLE
add lib/dialer - more robust dialer logic with least-connection policy

### DIFF
--- a/cmd/tcplb/server.go
+++ b/cmd/tcplb/server.go
@@ -72,7 +72,7 @@ func makeDialerFromConfig(cfg *Config, logger slog.Logger) (forwarder.BestUpstre
 	dialer := &dialer.RetryDialer{
 		Logger:      logger,
 		Timeout:     defaultDialerTimeout,
-		Policy:      dialer.PlaceholderDialPolicy{}, // TODO FIXME replace PlaceholderDialPolicy with something better
+		Policy:      dialer.NewLeastConnectionDialPolicy(),
 		InnerDialer: dialer.SimpleUpstreamDialer{},
 	}
 	return dialer, nil

--- a/lib/dialer/policies.go
+++ b/lib/dialer/policies.go
@@ -1,11 +1,15 @@
 package dialer
 
 import (
+	"math"
+	"sync"
 	"tcplb/lib/core"
 )
 
 // PlaceholderDialPolicy is an example of a simple but not very useful DialPolicy.
 // It arbitrarily chooses an upstream to dial in an implementation defined way.
+//
+// Multiple goroutines may invoke methods on an PlaceholderDialPolicy simultaneously.
 type PlaceholderDialPolicy struct{}
 
 func (p PlaceholderDialPolicy) ChooseBestUpstream(candidates core.UpstreamSet) (core.Upstream, error) {
@@ -21,4 +25,65 @@ func (p PlaceholderDialPolicy) DialSucceeded(upstream core.Upstream) {}
 
 func (p PlaceholderDialPolicy) ConnectionClosed(upstream core.Upstream) {}
 
-// TODO add least-connection dial policy
+// LeastConnectionDialPolicy is a DialPolicy that always chooses an upstream
+// that has the minimal number of connections among the candidate upstreams.
+//
+// Multiple goroutines may invoke methods on a LeastConnectionDialPolicy simultaneously.
+type LeastConnectionDialPolicy struct {
+	// TODO could use fine-grain locks, one per upstream. That could reduce lock contention
+	// in situations where different clients make concurrent connection attempts with
+	// disjoint sets of candidates. But in case where concurrent connection attempts have
+	// overlapping or identical sets of candidate upstreams, it isn't clear (without
+	//running experiments) how much that could help.
+	mu              sync.Mutex
+	connectionCount map[core.Upstream]int64
+}
+
+// NewLeastConnectionDialPolicy returns a new LeastConnectionDialPolicy
+func NewLeastConnectionDialPolicy() *LeastConnectionDialPolicy {
+	return &LeastConnectionDialPolicy{
+		connectionCount: make(map[core.Upstream]int64),
+	}
+}
+
+func (p *LeastConnectionDialPolicy) ChooseBestUpstream(candidates core.UpstreamSet) (core.Upstream, error) {
+	var minCount int64 = math.MaxInt64
+	argMin := core.Upstream{}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Doing a linear scan over all candidate upstreams does not seem ideal, but it'd
+	// be surprising if we have more than 1000 upstreams. Even if we had 10,000 or more,
+	// the time to do the scan is insignificant compared to a roundtrip over network.
+	for upstream := range candidates {
+		count := p.connectionCount[upstream]
+		if count < minCount {
+			minCount = count
+			argMin = upstream
+		}
+	}
+
+	var err error
+	if minCount == math.MaxInt64 {
+		err = NoCandidateUpstreams
+	}
+
+	return argMin, err
+}
+
+func (p *LeastConnectionDialPolicy) DialFailed(upstream core.Upstream, symptom error) {
+	// A failed connection attempt does not change the connection count.
+}
+
+func (p *LeastConnectionDialPolicy) DialSucceeded(upstream core.Upstream) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.connectionCount[upstream]++
+}
+
+func (p *LeastConnectionDialPolicy) ConnectionClosed(upstream core.Upstream) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.connectionCount[upstream]--
+}

--- a/lib/dialer/policies.go
+++ b/lib/dialer/policies.go
@@ -1,0 +1,24 @@
+package dialer
+
+import (
+	"tcplb/lib/core"
+)
+
+// PlaceholderDialPolicy is an example of a simple but not very useful DialPolicy.
+// It arbitrarily chooses an upstream to dial in an implementation defined way.
+type PlaceholderDialPolicy struct{}
+
+func (p PlaceholderDialPolicy) ChooseBestUpstream(candidates core.UpstreamSet) (core.Upstream, error) {
+	for upstream := range candidates {
+		return upstream, nil
+	}
+	return core.Upstream{}, NoCandidateUpstreams
+}
+
+func (p PlaceholderDialPolicy) DialFailed(upstream core.Upstream, symptom error) {}
+
+func (p PlaceholderDialPolicy) DialSucceeded(upstream core.Upstream) {}
+
+func (p PlaceholderDialPolicy) ConnectionClosed(upstream core.Upstream) {}
+
+// TODO add least-connection dial policy

--- a/lib/dialer/policies_test.go
+++ b/lib/dialer/policies_test.go
@@ -1,0 +1,63 @@
+package dialer
+
+import (
+	"github.com/stretchr/testify/require"
+	"tcplb/lib/core"
+	"testing"
+)
+
+func TestLeastConnectionDialPolicy_Err_When_NoCandidates(t *testing.T) {
+	policy := NewLeastConnectionDialPolicy()
+	_, err := policy.ChooseBestUpstream(core.EmptyUpstreamSet())
+	require.ErrorIs(t, err, NoCandidateUpstreams)
+}
+
+func TestLeastConnectionDialPolicy_ChoosesDifferentUpstreamAfterFirstChoiceSucceeds(t *testing.T) {
+	// Basic scenario that policy might be able to balance load.
+	a := core.Upstream{Network: "test-policies", Address: "a"}
+	b := core.Upstream{Network: "test-policies", Address: "b"}
+	candidates := core.NewUpstreamSet(a, b)
+	policy := NewLeastConnectionDialPolicy()
+
+	choice1, err := policy.ChooseBestUpstream(candidates)
+	require.NoError(t, err)
+	policy.DialSucceeded(choice1)
+	choice2, err := policy.ChooseBestUpstream(candidates)
+	require.NoError(t, err)
+	require.NotEqual(t, choice1, choice2)
+}
+
+func TestLeastConnectionDialPolicy_Catchup(t *testing.T) {
+	// Scenario where we open multiple connections to the first
+	// upstream chosen by the policy, to check that it focuses on
+	// choosing the other upstream.
+	a := core.Upstream{Network: "test-policies", Address: "a"}
+	b := core.Upstream{Network: "test-policies", Address: "b"}
+	candidates := core.NewUpstreamSet(a, b)
+	policy := NewLeastConnectionDialPolicy()
+
+	choice1, err := policy.ChooseBestUpstream(candidates)
+	require.NoError(t, err)
+
+	n := 5
+	for i := 0; i < n; i++ {
+		policy.DialSucceeded(choice1)
+	}
+
+	for i := 0; i < n; i++ {
+		choice2, err := policy.ChooseBestUpstream(candidates)
+		require.NoError(t, err)
+		require.NotEqual(t, choice1, choice2)
+		policy.DialSucceeded(choice2)
+	}
+
+	for i := 0; i < n; i++ {
+		policy.ConnectionClosed(choice1)
+	}
+
+	for i := 0; i < n; i++ {
+		choice3, err := policy.ChooseBestUpstream(candidates)
+		require.NoError(t, err)
+		require.Equal(t, choice1, choice3)
+	}
+}

--- a/lib/dialer/retrydialer.go
+++ b/lib/dialer/retrydialer.go
@@ -97,13 +97,16 @@ func (d *RetryDialer) DialBestUpstream(ctx context.Context, candidates core.Upst
 		if err != nil {
 			// If we exceeded the dial timeout, then dialCtx.Err() is non-nil
 			if dialCtxErr := dialCtx.Err(); dialCtxErr != nil {
+				d.Logger.Warn(&slog.LogRecord{Msg: "dial timed out", Upstream: &upstream})
 				// We cannot infer much about upstream health in this scenario.
 				// Halt and indicate to caller that we timed out.
 				return core.Upstream{}, nil, dialCtxErr
 			}
+			d.Logger.Warn(&slog.LogRecord{Msg: "dial failed", Upstream: &upstream})
 			d.Policy.DialFailed(upstream, err)
 			continue
 		}
+		d.Logger.Info(&slog.LogRecord{Msg: "dial succeeded", Upstream: &upstream})
 		d.Policy.DialSucceeded(upstream)
 
 		// Wrap & instrument the returned conn to inform the DialPolicy on conn Close.

--- a/lib/dialer/retrydialer.go
+++ b/lib/dialer/retrydialer.go
@@ -1,0 +1,109 @@
+package dialer
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"tcplb/lib/core"
+	"tcplb/lib/forwarder"
+	"tcplb/lib/slog"
+	"time"
+)
+
+// NoCandidateUpstreams is an error returned by RetryDialer if there are no
+// upstreams given as candidates to dial.
+var NoCandidateUpstreams = errors.New("no candidate upstreams")
+var ConnectionTypeUnsupported = errors.New("connection type is not supported")
+
+// DialPolicy controls which upstream to dial, out of a set of candidates.
+//
+// Multiple goroutines may invoke methods on a UpstreamDialer simultaneously.
+type DialPolicy interface {
+
+	// ChooseBestUpstream asks the policy to choose an upstream from the
+	// given set of candidates. In the case that the policy decides
+	// none of the candidates are feasible, an error is returned.
+	ChooseBestUpstream(candidates core.UpstreamSet) (core.Upstream, error)
+
+	// DialFailed informs the policy that a dial attempt failed
+	DialFailed(upstream core.Upstream, symptom error)
+
+	// DialSucceeded informs the policy that a dial attempt succeeded
+	DialSucceeded(upstream core.Upstream)
+
+	// ConnectionClosed informs the policy that a connection created by a prior
+	// successful dial attempt has been closed.
+	ConnectionClosed(upstream core.Upstream)
+}
+
+// UpstreamDialer dials upstreams.
+//
+// Multiple goroutines may invoke methods on a UpstreamDialer simultaneously.
+type UpstreamDialer interface {
+	// DialUpstream dials upstream, returning a DuplexConn if a connection is established.
+	// Implementations should honour context deadlines, timeouts, and cancellations (if any).
+	DialUpstream(ctx context.Context, upstream core.Upstream) (forwarder.DuplexConn, error)
+}
+
+type SimpleUpstreamDialer struct{}
+
+func (d SimpleUpstreamDialer) DialUpstream(ctx context.Context, upstream core.Upstream) (forwarder.DuplexConn, error) {
+	dd := net.Dialer{}
+	conn, err := dd.DialContext(ctx, upstream.Network, upstream.Address)
+	if err != nil {
+		return nil, err
+	}
+	switch c := conn.(type) {
+	case *net.TCPConn:
+		return c, nil
+	case *tls.Conn:
+		return c, nil
+	default:
+		_ = conn.Close()
+		return nil, ConnectionTypeUnsupported
+	}
+}
+
+// RetryDialer attempts to dial a candidate Upstream as selected by a
+// configurable DialPolicy. If the dial attempt fails, it informs the policy
+// of the failure and asks the policy for the next candidate upstream.
+// RetryDialer requires a Timeout to be supplied, which is shared across
+// all dial attempts.
+//
+// Multiple goroutines may invoke methods on a RetryDialer simultaneously.
+type RetryDialer struct {
+	Logger      slog.Logger
+	Timeout     time.Duration // Timeout to apply for each DialBestUpstream operation.
+	Policy      DialPolicy
+	InnerDialer UpstreamDialer
+}
+
+func (d *RetryDialer) DialBestUpstream(ctx context.Context, candidates core.UpstreamSet) (core.Upstream, forwarder.DuplexConn, error) {
+	if len(candidates) == 0 {
+		return core.Upstream{}, nil, NoCandidateUpstreams
+	}
+	// TODO use shorter timeout for each of n > 1 dial attempts?
+	dialCtx, cancel := context.WithTimeout(ctx, d.Timeout)
+	defer cancel()
+	for {
+		upstream, err := d.Policy.ChooseBestUpstream(candidates)
+		if err != nil {
+			// TODO could sleep here (honouring dialCtx timeout) to give policy chance to change its mind
+			return core.Upstream{}, nil, err
+		}
+		conn, err := d.InnerDialer.DialUpstream(dialCtx, upstream)
+		if err != nil {
+			// If we exceeded the dial timeout, then dialCtx.Err() is non-nil
+			if dialErr := dialCtx.Err(); dialErr != nil {
+				// We cannot infer much about upstream health in this scenario.
+				// Halt and indicate to caller that we timed out.
+				return core.Upstream{}, nil, dialErr
+			}
+			d.Policy.DialFailed(upstream, err)
+			continue
+		}
+		d.Policy.DialSucceeded(upstream)
+		return upstream, conn, nil
+	}
+}

--- a/lib/dialer/retrydialer.go
+++ b/lib/dialer/retrydialer.go
@@ -95,10 +95,10 @@ func (d *RetryDialer) DialBestUpstream(ctx context.Context, candidates core.Upst
 		conn, err := d.InnerDialer.DialUpstream(dialCtx, upstream)
 		if err != nil {
 			// If we exceeded the dial timeout, then dialCtx.Err() is non-nil
-			if dialErr := dialCtx.Err(); dialErr != nil {
+			if dialCtxErr := dialCtx.Err(); dialCtxErr != nil {
 				// We cannot infer much about upstream health in this scenario.
 				// Halt and indicate to caller that we timed out.
-				return core.Upstream{}, nil, dialErr
+				return core.Upstream{}, nil, dialCtxErr
 			}
 			d.Policy.DialFailed(upstream, err)
 			continue

--- a/lib/dialer/retrydialer.go
+++ b/lib/dialer/retrydialer.go
@@ -90,11 +90,12 @@ func (d *RetryDialer) DialBestUpstream(ctx context.Context, candidates core.Upst
 	for {
 		upstream, err := d.Policy.ChooseBestUpstream(candidates)
 		if err != nil {
-			// TODO could sleep here (honouring dialCtx timeout) to give policy chance to change its mind
+			// TODO instead of aborting, we could pause here
+			// (honouring dialCtx timeout) to give policy chance to change its mind.
 			return core.Upstream{}, nil, err
 		}
 		// TODO if policy chose an upstream we tried earlier this call, we could also
-		// pause here with an exponential backoff.
+		// pause here (honouring dialCtx timeout) with an exponential backoff.
 
 		conn, err := d.InnerDialer.DialUpstream(dialCtx, upstream)
 		if err != nil {

--- a/lib/dialer/retrydialer.go
+++ b/lib/dialer/retrydialer.go
@@ -93,6 +93,9 @@ func (d *RetryDialer) DialBestUpstream(ctx context.Context, candidates core.Upst
 			// TODO could sleep here (honouring dialCtx timeout) to give policy chance to change its mind
 			return core.Upstream{}, nil, err
 		}
+		// TODO if policy chose an upstream we tried earlier this call, we could also
+		// pause here with an exponential backoff.
+
 		conn, err := d.InnerDialer.DialUpstream(dialCtx, upstream)
 		if err != nil {
 			// If we exceeded the dial timeout, then dialCtx.Err() is non-nil

--- a/lib/dialer/retrydialer_test.go
+++ b/lib/dialer/retrydialer_test.go
@@ -1,0 +1,299 @@
+package dialer
+
+import (
+	"context"
+	"errors"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net"
+	"tcplb/lib/core"
+	"tcplb/lib/forwarder"
+	"testing"
+	"time"
+)
+
+// various mock & fake objects to test against:
+
+type connErrPair struct {
+	Conn forwarder.DuplexConn
+	Err  error
+}
+
+// fakeDialer resolves dials with a lookup table.
+type fakeDialer struct {
+	DialDelay        time.Duration
+	ResultByUpstream map[core.Upstream]connErrPair
+}
+
+func (d *fakeDialer) DialUpstream(ctx context.Context, upstream core.Upstream) (forwarder.DuplexConn, error) {
+	result, ok := d.ResultByUpstream[upstream]
+	if !ok {
+		return nil, errors.New("unknown upstream")
+	}
+	if d.DialDelay > 0 {
+		timer := time.NewTimer(d.DialDelay)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return result.Conn, result.Err
+}
+
+// blackholeConn is a DuplexConn from which bytes cannot escape.
+type blackholeConn struct{}
+
+func (c *blackholeConn) Read(b []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
+func (c *blackholeConn) Write(b []byte) (n int, err error) {
+	return len(b), nil
+}
+
+func (c *blackholeConn) Close() error {
+	return nil
+}
+
+func (c *blackholeConn) CloseWrite() error {
+	return nil
+}
+
+func (c *blackholeConn) LocalAddr() net.Addr {
+	return nil // FIXME
+}
+
+func (c *blackholeConn) RemoteAddr() net.Addr {
+	return nil // FIXME
+}
+
+func (c *blackholeConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *blackholeConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (c *blackholeConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+var _ forwarder.DuplexConn = (*blackholeConn)(nil)
+
+type UpstreamErrPair struct {
+	Upstream core.Upstream
+	Error    error
+}
+
+// MockDialPolicy returns upstreams prepared earlier.
+type MockDialPolicy struct {
+	I       int
+	Results []UpstreamErrPair
+	Events  []string
+}
+
+func (p *MockDialPolicy) ChooseBestUpstream(candidates core.UpstreamSet) (core.Upstream, error) {
+	p.Events = append(p.Events, "ChooseBestUpstream")
+	result := p.Results[p.I%len(p.Results)]
+	p.I++
+	return result.Upstream, result.Error
+}
+
+func (p *MockDialPolicy) DialFailed(upstream core.Upstream, symptom error) {
+	p.Events = append(p.Events, "DialFailed")
+}
+
+func (p *MockDialPolicy) DialSucceeded(upstream core.Upstream) {
+	p.Events = append(p.Events, "DialSucceeded")
+}
+
+func (p *MockDialPolicy) ConnectionClosed(upstream core.Upstream) {
+	p.Events = append(p.Events, "ConnectionClosed")
+}
+
+// RetryDialer test scenarios
+
+func TestRetryDialer_DialBestUpstream_Err_When_NoCandidates(t *testing.T) {
+	// When DialBestUpstream is called with empty set of candidates
+	// it should immediately return NoCandidateUpstreams error.
+	rd := &RetryDialer{}
+
+	ctx := context.Background()
+	candidates := core.EmptyUpstreamSet()
+	_, conn, err := rd.DialBestUpstream(ctx, candidates)
+	require.ErrorIs(t, err, NoCandidateUpstreams)
+	require.Nil(t, conn)
+}
+
+func TestRetryDialer_DialBestUpstream_Err_When_ChooseErr(t *testing.T) {
+	// When DialBestUpstream is called with nonempty set of candidates
+	// if the first ChooseBestUpstream call returns an error
+	// it should immediately return that error.
+	upstream := core.Upstream{Network: "test-retrydialer", Address: "a"}
+	candidates := core.NewUpstreamSet(upstream)
+
+	chooseErr := errors.New("indecision")
+	policy := &MockDialPolicy{
+		Results: []UpstreamErrPair{
+			{Upstream: core.Upstream{}, Error: chooseErr},
+		},
+		Events: make([]string, 0),
+	}
+	rd := &RetryDialer{
+		Policy: policy,
+	}
+
+	ctx := context.Background()
+	_, conn, err := rd.DialBestUpstream(ctx, candidates)
+	require.ErrorIs(t, err, chooseErr)
+	require.Nil(t, conn)
+}
+
+func TestRetryDialer_DialBestUpstream_Success_Close(t *testing.T) {
+	// When DialBestUpstream is called with nonempty set of candidates
+	// if the first ChooseBestUpstream returns some candidate upstream
+	// it should call the inner dialer, and if that succeeds, it should
+	// return a conn. Calling Close on the conn should result in a call
+	// to ConnectionClosed on the policy.
+	upstream := core.Upstream{Network: "test-retrydialer", Address: "a"}
+	candidates := core.NewUpstreamSet(upstream)
+
+	innerConn := &blackholeConn{}
+	policy := &MockDialPolicy{
+		Results: []UpstreamErrPair{
+			{Upstream: upstream, Error: nil},
+		},
+		Events: make([]string, 0),
+	}
+	rd := &RetryDialer{
+		Policy:  policy,
+		Timeout: time.Second,
+		InnerDialer: &fakeDialer{
+			ResultByUpstream: map[core.Upstream]connErrPair{
+				upstream: {
+					innerConn,
+					nil,
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	_, conn, err := rd.DialBestUpstream(ctx, candidates)
+	require.NoError(t, err)
+
+	expectedEvents := []string{
+		"ChooseBestUpstream",
+		"DialSucceeded",
+	}
+	require.Equal(t, expectedEvents, policy.Events)
+
+	err = conn.Close()
+	require.NoError(t, err)
+
+	expectedEvents = []string{
+		"ChooseBestUpstream",
+		"DialSucceeded",
+		"ConnectionClosed",
+	}
+	require.Equal(t, expectedEvents, policy.Events)
+}
+
+func TestRetryDialer_DialBestUpstream_Failure_Retry_Success_Close(t *testing.T) {
+	// Scenario where first Dial attempt fails, then retry with a different
+	// upstream, which succeeds
+	unhealthy := core.Upstream{Network: "test-retrydialer", Address: "unhealthy"}
+	healthy := core.Upstream{Network: "test-retrydialer", Address: "heathy"}
+	candidates := core.NewUpstreamSet(unhealthy, healthy)
+
+	innerConn := &blackholeConn{}
+	policy := &MockDialPolicy{
+		Results: []UpstreamErrPair{
+			{Upstream: unhealthy, Error: nil},
+			{Upstream: healthy, Error: nil},
+		},
+		Events: make([]string, 0),
+	}
+	rd := &RetryDialer{
+		Policy:  policy,
+		Timeout: time.Second,
+		InnerDialer: &fakeDialer{
+			ResultByUpstream: map[core.Upstream]connErrPair{
+				unhealthy: {
+					nil,
+					errors.New("unhealthy upstream is resting in bed"),
+				},
+				healthy: {
+					innerConn,
+					nil,
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	_, conn, err := rd.DialBestUpstream(ctx, candidates)
+	require.NoError(t, err)
+
+	expectedEvents := []string{
+		"ChooseBestUpstream",
+		"DialFailed",
+		"ChooseBestUpstream",
+		"DialSucceeded",
+	}
+	require.Equal(t, expectedEvents, policy.Events)
+
+	err = conn.Close()
+	require.NoError(t, err)
+
+	expectedEvents = []string{
+		"ChooseBestUpstream",
+		"DialFailed",
+		"ChooseBestUpstream",
+		"DialSucceeded",
+		"ConnectionClosed",
+	}
+	require.Equal(t, expectedEvents, policy.Events)
+}
+
+func TestRetryDialer_DialBestUpstream_Dial_Timeout(t *testing.T) {
+	// Scenario where RetryDialer returns error after first Dial attempt times out.
+
+	uncommunicative := core.Upstream{Network: "test-retrydialer", Address: "uncommunicative"}
+	candidates := core.NewUpstreamSet(uncommunicative)
+
+	innerConn := &blackholeConn{}
+	policy := &MockDialPolicy{
+		Results: []UpstreamErrPair{
+			{Upstream: uncommunicative, Error: nil},
+		},
+		Events: make([]string, 0),
+	}
+	rd := &RetryDialer{
+		Policy:  policy,
+		Timeout: time.Nanosecond,
+		InnerDialer: &fakeDialer{
+			DialDelay: time.Millisecond,
+			ResultByUpstream: map[core.Upstream]connErrPair{
+				uncommunicative: {
+					innerConn,
+					nil,
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	_, _, err := rd.DialBestUpstream(ctx, candidates)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	expectedEvents := []string{
+		"ChooseBestUpstream",
+	}
+	require.Equal(t, expectedEvents, policy.Events)
+}

--- a/lib/dialer/retrydialer_test.go
+++ b/lib/dialer/retrydialer_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"tcplb/lib/core"
 	"tcplb/lib/forwarder"
+	"tcplb/lib/slog"
 	"testing"
 	"time"
 )
@@ -143,6 +144,7 @@ func TestRetryDialer_DialBestUpstream_Err_When_ChooseErr(t *testing.T) {
 	}
 	rd := &RetryDialer{
 		Policy: policy,
+		Logger: slog.VoidLogger{},
 	}
 
 	ctx := context.Background()
@@ -178,6 +180,7 @@ func TestRetryDialer_DialBestUpstream_Success_Close(t *testing.T) {
 				},
 			},
 		},
+		Logger: slog.VoidLogger{},
 	}
 
 	ctx := context.Background()
@@ -232,6 +235,7 @@ func TestRetryDialer_DialBestUpstream_Failure_Retry_Success_Close(t *testing.T) 
 				},
 			},
 		},
+		Logger: slog.VoidLogger{},
 	}
 
 	ctx := context.Background()
@@ -285,6 +289,7 @@ func TestRetryDialer_DialBestUpstream_Dial_Timeout(t *testing.T) {
 				},
 			},
 		},
+		Logger: slog.VoidLogger{},
 	}
 
 	ctx := context.Background()

--- a/lib/slog/slog.go
+++ b/lib/slog/slog.go
@@ -123,3 +123,14 @@ func (l *RecordingLogger) Error(record *LogRecord) {
 }
 
 var _ Logger = (*RecordingLogger)(nil) // type check
+
+// VoidLogger discards all logged records.
+type VoidLogger struct{}
+
+func (l VoidLogger) Info(record *LogRecord) {}
+
+func (l VoidLogger) Warn(record *LogRecord) {}
+
+func (l VoidLogger) Error(record *LogRecord) {}
+
+var _ Logger = (*VoidLogger)(nil) // type check


### PR DESCRIPTION
included:

- add RetryDialer which attempts to connect to upstreams selected by DialPolicy
- DialPolicy implementations: Placeholder, LeastConnections
- tests

out of scope of this PR:
- healthchecks - probing upstreams & using upstream health information in the dial policy
- securing the inbound client connection