### PR TITLE
draft: healthcheck

### DIFF
--- a/lib/forwarder/dialer.go
+++ b/lib/forwarder/dialer.go
@@ -1,0 +1,32 @@
+package forwarder
+
+import (
+	"context"
+	"net"
+	"tcplb/lib/core"
+	"time"
+)
+
+type CloseWriter interface {
+	CloseWrite() error // CloseWrite shuts down the writer side of a connection.
+}
+
+type UpstreamConn interface {
+	net.Conn
+	CloseWriter
+}
+
+type UpstreamDialer interface {
+	DialUpstream(ctx context.Context, u core.Upstream) (UpstreamConn, error)
+}
+
+type TimeoutDialer struct {
+	Timeout time.Duration
+	Inner   UpstreamDialer
+}
+
+func (d TimeoutDialer) DialUpstream(ctx context.Context, u core.Upstream) (UpstreamConn, error) {
+	childCtx, cancel := context.WithTimeout(ctx, d.Timeout)
+	defer cancel()
+	return d.Inner.DialUpstream(childCtx, u)
+}

--- a/lib/healthcheck/beliefhealthtracker.go
+++ b/lib/healthcheck/beliefhealthtracker.go
@@ -1,0 +1,145 @@
+package healthcheck
+
+import (
+	"sync"
+	"tcplb/lib/core"
+)
+
+type HealthBeliefState uint8
+
+const (
+	HEALTHY HealthBeliefState = iota
+	UNHEALTHY
+)
+
+// Config holds configuration for a BeliefHealthTracker
+type Config struct {
+	// HealthBeliefState is the initial HealthBeliefState value to use
+	// for the health of an upstream, before any observations are known.
+	Prior HealthBeliefState
+
+	// MinFailuresToInferUnhealthy is the minimum number of consecutive
+	// CheckResult observations with the value CheckFail for the belief
+	// state to transition to UNHEALTHY.
+	MinFailuresToInferUnhealthy uint8
+
+	// MinSuccessesToInferHealthy is the minimum number of consecutive
+	// CheckResult observations with the value CheckSuccess for the belief
+	// state to transition to UNHEALTHY.
+	MinSuccessesToInferHealthy uint8
+}
+
+// BeliefHealthTracker maintains a belief state about the health of each
+// upstream. All upstreams in scope for health tracking must be registered
+// when the BeliefHealthTracker is created by NewBeliefHealthTracker.
+type BeliefHealthTracker struct {
+	beliefStateByUpstream map[core.Upstream]*upstreamBeliefState
+}
+
+func NewBeliefHealthTracker(upstreams core.UpstreamSet, cfg Config) *BeliefHealthTracker {
+	beliefStateByUpstream := make(map[core.Upstream]*upstreamBeliefState)
+	for u := range upstreams {
+		beliefStateByUpstream[u] = &upstreamBeliefState{
+			cfg:       cfg,
+			state:     cfg.Prior,
+			failures:  0,
+			successes: 0,
+		}
+	}
+	return &BeliefHealthTracker{
+		beliefStateByUpstream: beliefStateByUpstream,
+	}
+}
+
+// HealthyUpstreams returns a new UpstreamSet containing the subset of input
+// candidate upstreams that are currently believed to be healthy.
+//
+// Any unknown Upstreams in the candidate set are ignored.
+func (hc *BeliefHealthTracker) HealthyUpstreams(candidates core.UpstreamSet) core.UpstreamSet {
+	var result = core.EmptyUpstreamSet()
+
+	// TODO sweep requires acquiring many locks. Can we relax it?
+	for u := range candidates {
+		_, exists := hc.beliefStateByUpstream[u]
+		if !exists {
+			continue // Upstream was not previously registered, ignore.
+		}
+		beliefState := hc.beliefStateByUpstream[u]
+		if beliefState.CurrentBelief() == HEALTHY {
+			result[u] = struct{}{}
+		}
+	}
+	return result
+}
+
+// ReportUpstreamHealth accepts a HealthReport.
+//
+// If the report is for unknown Upstream, it is ignored.
+func (hc *BeliefHealthTracker) ReportUpstreamHealth(report *HealthReport) {
+	if report == nil {
+		return
+	}
+	beliefState, exists := hc.beliefStateByUpstream[report.Upstream]
+	if !exists {
+		return // Upstream was not previously registered, ignore.
+	}
+	beliefState.UpdateBelief(report)
+}
+
+// upstreamBeliefState encodes the current belief about the health
+// of a single upstream. It must not be copied.
+type upstreamBeliefState struct {
+	// cfg is never modified after initialisation
+	cfg Config
+
+	// mu guards the below state variables
+	mu        sync.Mutex // TODO consider replacing with sync RWmutex
+	state     HealthBeliefState
+	failures  uint8
+	successes uint8
+}
+
+func min(a, b uint8) uint8 {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}
+
+func (s *upstreamBeliefState) UpdateBelief(report *HealthReport) {
+	if report == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.updateBeliefLocked(report)
+}
+
+func (s *upstreamBeliefState) updateBeliefLocked(report *HealthReport) {
+	switch report.CheckResult {
+	case CheckSuccess:
+		s.failures = 0
+		s.successes = min(s.successes+1, s.cfg.MinSuccessesToInferHealthy)
+		if s.successes >= s.cfg.MinSuccessesToInferHealthy {
+			s.state = HEALTHY
+		}
+	case CheckFail:
+		s.failures = min(s.failures+1, s.cfg.MinFailuresToInferUnhealthy)
+		s.successes = 0
+		if s.failures >= s.cfg.MinFailuresToInferUnhealthy {
+			s.state = UNHEALTHY
+		}
+	}
+}
+
+func (s *upstreamBeliefState) CurrentBelief() HealthBeliefState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.state
+}
+
+// type check *BeliefHealthTracker satisfies HealthReportSink interface
+var _ HealthReportSink = (*BeliefHealthTracker)(nil)

--- a/lib/healthcheck/probepool.go
+++ b/lib/healthcheck/probepool.go
@@ -1,0 +1,181 @@
+package healthcheck
+
+import (
+	"context"
+	"sync"
+	"tcplb/lib/core"
+	"tcplb/lib/forwarder"
+	"time"
+)
+
+type HealthCheckResult int8
+
+const (
+	CheckFail HealthCheckResult = iota
+	CheckSuccess
+)
+
+type UpstreamDialer interface {
+	DialUpstream(ctx context.Context, u core.Upstream) (forwarder.DuplexConn, error)
+}
+
+type TimeoutDialer struct {
+	Timeout time.Duration
+	Inner   UpstreamDialer
+}
+
+func (d TimeoutDialer) DialUpstream(ctx context.Context, u core.Upstream) (forwarder.DuplexConn, error) {
+	childCtx, cancel := context.WithTimeout(ctx, d.Timeout)
+	defer cancel()
+	return d.Inner.DialUpstream(childCtx, u)
+}
+
+// HealthReport contains information from a single observation
+// of upstream health - perhaps from a successful or failed
+// connection attempt, or the result of an active probe.
+type HealthReport struct {
+	Upstream    core.Upstream
+	CheckResult HealthCheckResult
+	Symptom     error // Symptom may optionally contain information relating to a failed check
+}
+
+// HealthReportSink represents an entity that can be used by the
+// ProbePool to receive upstream health reports.
+//
+// Multiple goroutines may invoke methods on a HealthReportSink
+// simultaneously.
+type HealthReportSink interface {
+
+	// ReportUpstreamHealth receives a HealthReport.
+	ReportUpstreamHealth(report *HealthReport)
+}
+
+type ProbePoolConfig struct {
+	HealthReportSink HealthReportSink
+	ProbePeriod      time.Duration
+	Upstreams        core.UpstreamSet
+	Dialer           UpstreamDialer
+}
+
+// ProbePool probes a set of upstreams on a periodic schedule,
+// reporting probe outcomes to a HealthReportSink. To initialise
+// a ProbePool, call NewProbePool. To start an initialised
+// ProbePool, call Start.
+//
+// Multiple goroutines may invoke methods on a ProbePool.
+type ProbePool struct {
+	cfg ProbePoolConfig
+
+	// mu guards state variables below
+	mu      sync.Mutex
+	started bool
+	stopped bool
+	done    context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// NewProbePool creates a new ProbePool from the given ProbePoolConfig.
+func NewProbePool(cfg ProbePoolConfig) *ProbePool {
+	return &ProbePool{
+		cfg: cfg,
+	}
+}
+
+// Start starts a ProbePool that has been initialised but not yet
+// started. After launching probes, Start will return without
+// blocking. Health observations will be reported to the configured
+// HealthReportSink asynchronously.
+func (ap *ProbePool) Start(ctx context.Context) {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	probeCtx, probeCancel := context.WithCancel(ctx)
+	ap.done = probeCancel
+
+	if ap.started {
+		return
+	}
+	ap.started = true
+	ap.stopped = false
+	for u := range ap.cfg.Upstreams {
+		ap.wg.Add(1)
+		w := newWorker(workerConfig{
+			Upstream:         u,
+			Period:           ap.cfg.ProbePeriod,
+			HealthReportSink: ap.cfg.HealthReportSink,
+			Dialer:           ap.cfg.Dialer,
+			WaitGroup:        &ap.wg,
+		})
+		go w.probeForever(probeCtx)
+	}
+}
+
+// Stop stops a ProbePool that was previously started.
+// Stop cancels probing, and blocks until all probes are stopped.
+func (ap *ProbePool) Stop() {
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+
+	if !ap.started || ap.stopped {
+		return
+	}
+
+	ap.started = false
+	ap.stopped = true
+	ap.done() // cancel parent context for all probe workers
+	// wait for all probe workers to stop
+	ap.wg.Wait()
+}
+
+type workerConfig struct {
+	Upstream         core.Upstream
+	Period           time.Duration
+	HealthReportSink HealthReportSink
+	Dialer           UpstreamDialer
+	WaitGroup        *sync.WaitGroup
+	// TODO add logger to observe what probe Workers do
+}
+
+// worker is responsible for actively probing the health of a single
+// configured upstream according to a periodic schedule.
+type worker struct {
+	cfg workerConfig
+}
+
+func newWorker(cfg workerConfig) *worker {
+	return &worker{
+		cfg: cfg,
+	}
+}
+
+func (w *worker) probeForever(ctx context.Context) {
+	defer w.cfg.WaitGroup.Done()
+
+	// TODO could add initial delay to smooth out probe schedule network impact.
+	// TODO could add jitter to smooth out probe schedule network impact.
+
+	ticker := time.NewTicker(w.cfg.Period)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			// TODO could guard against panic in dialer by trapping panics
+			// and logging them or reporting them to the HealthReportSink.
+
+			// The dialer is responsible for setting connect timeout.
+			conn, err := w.cfg.Dialer.DialUpstream(ctx, w.cfg.Upstream)
+			var report HealthReport
+			report.Upstream = w.cfg.Upstream
+			if err != nil {
+				report.Symptom = err
+				report.CheckResult = CheckFail
+			} else {
+				report.CheckResult = CheckSuccess
+				_ = conn.Close()
+			}
+			w.cfg.HealthReportSink.ReportUpstreamHealth(&report)
+		}
+	}
+}

--- a/lib/healthcheck/trivial.go
+++ b/lib/healthcheck/trivial.go
@@ -1,0 +1,18 @@
+package healthcheck
+
+import (
+	"tcplb/lib/core"
+)
+
+// AlwaysHealthyChecker is a trivial health tracker that reports all upstreams are healthy.
+type AlwaysHealthyChecker struct{}
+
+func (hc AlwaysHealthyChecker) HealthyUpstreams(candidates core.UpstreamSet) core.UpstreamSet {
+	return candidates
+}
+
+func (hc AlwaysHealthyChecker) ReportUpstreamHealth(report *HealthReport) {
+}
+
+// type check *AlwaysHealthyChecker satisfies HealthReportSink interface
+var _ HealthReportSink = (*BeliefHealthTracker)(nil)


### PR DESCRIPTION
this was some prototype library code for the healthcheck

it isn't integrated into the application yet

The next steps with this would be to:
- adjust the `BeliefHealthTracker` so it can compose with `LeastConnectionDialPolicy` and be triggered by the existing dialer logic through the `DialPolicy`. the input candidate upstream set would be intersected with the set of believed-healthy upstreams, so the dialer would only propose dialing healthy upstreams, then taking into account the least connection policy
- modify the main server application to launch the pool of probe goroutines in addition to starting the server, and wire things so that both the pool of probe goroutines and the connection attempts triggered by the dialer feed health check observations into a single BeliefHealthTracker .